### PR TITLE
Removed code that does not contribute to the result

### DIFF
--- a/base64.cpp
+++ b/base64.cpp
@@ -71,7 +71,6 @@ std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_
     char_array_4[0] = ( char_array_3[0] & 0xfc) >> 2;
     char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
     char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
-    char_array_4[3] =   char_array_3[2] & 0x3f;
 
     for (j = 0; (j < i + 1); j++)
       ret += base64_chars[char_array_4[j]];
@@ -110,15 +109,11 @@ std::string base64_decode(std::string const& encoded_string) {
   }
 
   if (i) {
-    for (j = i; j <4; j++)
-      char_array_4[j] = 0;
-
-    for (j = 0; j <4; j++)
+    for (j = 0; j < i; j++)
       char_array_4[j] = base64_chars.find(char_array_4[j]);
 
     char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
     char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
-    char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
 
     for (j = 0; (j < i - 1); j++) ret += char_array_3[j];
   }

--- a/test.cpp
+++ b/test.cpp
@@ -13,5 +13,44 @@ int main() {
   std::cout << "encoded: " << std::endl << encoded << std::endl << std::endl;
   std::cout << "decoded: " << std::endl << decoded << std::endl;
 
+
+  // Test all possibilites of fill bytes (none, one =, two ==)
+  // References calculated with: https://www.base64encode.org/
+
+  std::string rest0_original = "abc";
+  std::string rest0_reference = "YWJj";
+
+  std::string rest0_encoded = base64_encode(reinterpret_cast<const unsigned char*>(rest0_original.c_str()),
+    rest0_original.length());
+  std::string rest0_decoded = base64_decode(rest0_encoded);
+
+  std::cout << "encoded:   " << rest0_encoded << std::endl;
+  std::cout << "reference: " << rest0_reference << std::endl;
+  std::cout << "decoded:   " << rest0_decoded << std::endl << std::endl;
+
+
+  std::string rest1_original = "abcd";
+  std::string rest1_reference = "YWJjZA==";
+
+  std::string rest1_encoded = base64_encode(reinterpret_cast<const unsigned char*>(rest1_original.c_str()),
+    rest1_original.length());
+  std::string rest1_decoded = base64_decode(rest1_encoded);
+
+  std::cout << "encoded:   " << rest1_encoded << std::endl;
+  std::cout << "reference: " << rest1_reference << std::endl;
+  std::cout << "decoded:   " << rest1_decoded << std::endl << std::endl;
+
+
+  std::string rest2_original = "abcde";
+  std::string rest2_reference = "YWJjZGU=";
+
+  std::string rest2_encoded = base64_encode(reinterpret_cast<const unsigned char*>(rest2_original.c_str()),
+    rest2_original.length());
+  std::string rest2_decoded = base64_decode(rest2_encoded);
+
+  std::cout << "encoded:   " << rest2_encoded << std::endl;
+  std::cout << "reference: " << rest2_reference << std::endl;
+  std::cout << "decoded:   " << rest2_decoded << std::endl << std::endl;
+
   return 0;
 }


### PR DESCRIPTION
While working on a derived implementation of the base64 code, I got an exception in the decode function and started wondering what the find() function (line 117) would return when it gets one of the 0-bytes that have been put to char_array_4 in line 114. It is actually std::string::npos, thus -1. All bits set?? Does not sound like base64.

So I noticed that the block after "if (i)" is only entered for i = 2 or 3. That narrows j in the for loop in line 116 to 0, 1 or 2. -> char_array_4[3] is no longer accessed.
Also, since this block handles the cases where 1 or 2 bytes of the original buffer are encoded into 4 bytes, where only char_array_3[0] and char_array_3[1] are used which renders line 121 useless.

As a consequence, the whole filling with zeros in lines 113 and 114 is not necessary at all and can be omitted. Just adapt the following for loop to not use these bytes.

A similar situation applies in line 74 of the encode function: the block after "if (i)" handles cases where one or two original bytes are encoded (i = 1 or 2), but not 3, so char_array_3[2] is not needed, therefore char_array_4[3] likewise. The for loop in line 76 can generate j = 0, 1 or 2 (thus, again, char_array_4[3] is never accessed).

I added some more tests where all three cases are tested: number of bytes divisible by 3 (thus, i=0, no '='), and those with rest 1 and 2 (i.e. two trailing ==, or one =, resp.).