### PR TITLE
Remove unused library

### DIFF
--- a/base64.cpp
+++ b/base64.cpp
@@ -30,7 +30,7 @@
 */
 
 #include "base64.h"
-#include <iostream>
+#include <cctype>
 
 static const std::string base64_chars = 
              "ABCDEFGHIJKLMNOPQRSTUVWXYZ"


### PR DESCRIPTION
We only need include `cctype` to use `isalnum` function.