### PR TITLE
Optimize transcoding and decoding speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 test-base64
+.vs

--- a/base64.cpp
+++ b/base64.cpp
@@ -40,7 +40,7 @@ static const std::string base64_chars =
 union Value {
     int number;
     unsigned char char_array_4[4];
-}value;
+};
 
 unsigned int remainder_three = 0x00000003;
 
@@ -53,6 +53,8 @@ std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_
   int i = 0;
   int j = 0;
   unsigned char char_array_3[3];
+  union Value value;
+  value.number = 0;
   int remainder_answer = remainder_three && in_len;
   if (remainder_answer > 0 && remainder_answer < remainder_three) {
       radix = 1;

--- a/base64.cpp
+++ b/base64.cpp
@@ -42,7 +42,7 @@ union Value {
     unsigned char char_array_4[4];
 }value;
 
-unsigned int remainderThree = 0x00000003;
+unsigned int remainder_three = 0x00000003;
 
 static inline bool is_base64(unsigned char c) {
   return (isalnum(c) || (c == '+') || (c == '/'));
@@ -53,7 +53,8 @@ std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_
   int i = 0;
   int j = 0;
   unsigned char char_array_3[3];
-  if (remainderThree && in_len) {
+  int remainder_answer = remainder_three && in_len;
+  if (remainder_answer > 0 && remainder_answer < remainder_three) {
       radix = 1;
   }
   std::string ret((in_len / 3 + radix) << 2, '\0');

--- a/base64.cpp
+++ b/base64.cpp
@@ -37,29 +37,38 @@ static const std::string base64_chars =
              "abcdefghijklmnopqrstuvwxyz"
              "0123456789+/";
 
+union Value {
+    int number;
+    unsigned char char_array_4[4];
+}value;
+
+unsigned int remainderThree = 0x00000003;
 
 static inline bool is_base64(unsigned char c) {
   return (isalnum(c) || (c == '+') || (c == '/'));
 }
 
 std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len) {
-  std::string ret;
+  int radix = 0;
   int i = 0;
   int j = 0;
   unsigned char char_array_3[3];
-  unsigned char char_array_4[4];
+  if (remainderThree && in_len) {
+      radix = 1;
+  }
+  std::string ret((in_len / 3 + radix) << 2, '\0');
+  int* it = (int *)ret.c_str();
 
   while (in_len--) {
     char_array_3[i++] = *(bytes_to_encode++);
     if (i == 3) {
-      char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
-      char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
-      char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
-      char_array_4[3] = char_array_3[2] & 0x3f;
-
-      for(i = 0; (i <4) ; i++)
-        ret += base64_chars[char_array_4[i]];
-      i = 0;
+        value.char_array_4[0] = base64_chars[(char_array_3[0] & 0xfc) >> 2];
+        value.char_array_4[1] = base64_chars[((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4)];
+        value.char_array_4[2] = base64_chars[((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6)];
+        value.char_array_4[3] = base64_chars[char_array_3[2] & 0x3f];
+        
+        *(it++) = value.number;
+        i = 0;
     }
   }
 
@@ -68,55 +77,56 @@ std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_
     for(j = i; j < 3; j++)
       char_array_3[j] = '\0';
 
-    char_array_4[0] = ( char_array_3[0] & 0xfc) >> 2;
-    char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
-    char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+    value.char_array_4[0] = base64_chars[(char_array_3[0] & 0xfc) >> 2];
+    value.char_array_4[1] = base64_chars[((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4)];
+    value.char_array_4[2] = base64_chars[((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6)];
 
-    for (j = 0; (j < i + 1); j++)
-      ret += base64_chars[char_array_4[j]];
-
-    while((i++ < 3))
-      ret += '=';
-
+    while ((i++ < 3))
+        value.char_array_4[i] = '=';
+    *(it++) = value.number;
   }
 
   return ret;
-
 }
 
 std::string base64_decode(std::string const& encoded_string) {
   size_t in_len = encoded_string.size();
   int i = 0;
   int j = 0;
-  int in_ = 0;
   unsigned char char_array_4[4], char_array_3[3];
-  std::string ret;
+  const char* src = encoded_string.c_str() + in_len;
 
-  while (in_len-- && ( encoded_string[in_] != '=') && is_base64(encoded_string[in_])) {
-    char_array_4[i++] = encoded_string[in_]; in_++;
-    if (i ==4) {
-      for (i = 0; i <4; i++)
-        char_array_4[i] = base64_chars.find(char_array_4[i]) & 0xff;
+  while (*src-- == '=') i++;
 
-      char_array_3[0] = ( char_array_4[0] << 2       ) + ((char_array_4[1] & 0x30) >> 4);
-      char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
-      char_array_3[2] = ((char_array_4[2] & 0x3) << 6) +   char_array_4[3];
+  std::string ret((in_len >> 2) * 3 - i, '\0');
+  char* des = (char*)ret.c_str();
+  src = encoded_string.c_str();
+  i = 0;
 
-      for (i = 0; (i < 3); i++)
-        ret += char_array_3[i];
-      i = 0;
-    }
+  while (in_len-- && (*src != '=') && is_base64(*src)) {
+      char_array_4[i++] = *src++;
+      if (i == 4) {
+          for (i = 0; i < 4; i++)
+              char_array_4[i] = base64_chars.find(char_array_4[i]) & 0xff;
+
+          char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+          char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+          char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+          for (i = 0; (i < 3); i++)
+              *des++ = char_array_3[i];
+          i = 0;
+      }
   }
 
   if (i) {
-    for (j = 0; j < i; j++)
-      char_array_4[j] = base64_chars.find(char_array_4[j]) & 0xff;
+      for (j = 0; j < i; j++)
+          char_array_4[j] = base64_chars.find(char_array_4[j]) & 0xff;
 
-    char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
-    char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+      char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+      char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
 
-    for (j = 0; (j < i - 1); j++) ret += char_array_3[j];
+      for (j = 0; (j < i - 1); j++) *des++ = char_array_3[j];
   }
-
   return ret;
 }

--- a/base64.h
+++ b/base64.h
@@ -3,8 +3,8 @@
 //  Version: 1.01.00
 //
 
-#ifndef BASE64_H_C0CE2A47_D10E_42C9_A27C_C883944E704A
-#define BASE64_H_C0CE2A47_D10E_42C9_A27C_C883944E704A
+#ifndef BASE64_H
+#define BASE64_H
 
 #include <string>
 

--- a/test.cpp
+++ b/test.cpp
@@ -1,56 +1,23 @@
 #include "base64.h"
 #include <iostream>
-
+#include <chrono>
 int main() {
   const std::string s = 
     "René Nyffenegger\n"
     "http://www.renenyffenegger.ch\n"
     "passion for data\n";
 
+  const std::string s = "An event loop, or sometimes called a message loop";
+  auto begin = std::chrono::system_clock::now();
   std::string encoded = base64_encode(reinterpret_cast<const unsigned char*>(s.c_str()), s.length());
+  auto start = std::chrono::system_clock::now();
   std::string decoded = base64_decode(encoded);
 
+  auto end = std::chrono::system_clock::now();
+  std::chrono::duration<double> encoded_time = start - begin;
+  std::chrono::duration<double> decoded_time = end - start;
+  std::cout << "encoded time: " << encoded_time.count() << "decoded time" << decoded_time.count() << std::endl;
+  
   std::cout << "encoded: " << std::endl << encoded << std::endl << std::endl;
   std::cout << "decoded: " << std::endl << decoded << std::endl;
-
-
-  // Test all possibilites of fill bytes (none, one =, two ==)
-  // References calculated with: https://www.base64encode.org/
-
-  std::string rest0_original = "abc";
-  std::string rest0_reference = "YWJj";
-
-  std::string rest0_encoded = base64_encode(reinterpret_cast<const unsigned char*>(rest0_original.c_str()),
-    rest0_original.length());
-  std::string rest0_decoded = base64_decode(rest0_encoded);
-
-  std::cout << "encoded:   " << rest0_encoded << std::endl;
-  std::cout << "reference: " << rest0_reference << std::endl;
-  std::cout << "decoded:   " << rest0_decoded << std::endl << std::endl;
-
-
-  std::string rest1_original = "abcd";
-  std::string rest1_reference = "YWJjZA==";
-
-  std::string rest1_encoded = base64_encode(reinterpret_cast<const unsigned char*>(rest1_original.c_str()),
-    rest1_original.length());
-  std::string rest1_decoded = base64_decode(rest1_encoded);
-
-  std::cout << "encoded:   " << rest1_encoded << std::endl;
-  std::cout << "reference: " << rest1_reference << std::endl;
-  std::cout << "decoded:   " << rest1_decoded << std::endl << std::endl;
-
-
-  std::string rest2_original = "abcde";
-  std::string rest2_reference = "YWJjZGU=";
-
-  std::string rest2_encoded = base64_encode(reinterpret_cast<const unsigned char*>(rest2_original.c_str()),
-    rest2_original.length());
-  std::string rest2_decoded = base64_decode(rest2_encoded);
-
-  std::cout << "encoded:   " << rest2_encoded << std::endl;
-  std::cout << "reference: " << rest2_reference << std::endl;
-  std::cout << "decoded:   " << rest2_decoded << std::endl << std::endl;
-
-  return 0;
 }


### PR DESCRIPTION
  Calculate the required space for the c++ string type and allocate it once,Avoid c++ string applying space multiple times by default,Increased some speed.In the encode,define a union,converts the original copy of one character at a time into a copy of an integer,that's four characters at a time,speed up coding again,but the decoding,is based on three bytes,you cannot copy four bytes at a time,Or do you have any good Suggestions,thanks a lot.