### PR TITLE
Fixing implicit cast warnings

### DIFF
--- a/base64.cpp
+++ b/base64.cpp
@@ -101,9 +101,9 @@ static std::string encode(String s, bool url) {
   return base64_encode(reinterpret_cast<const unsigned char*>(s.data()), s.length(), url);
 }
 
-std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len, bool url) {
+std::string base64_encode(unsigned char const* bytes_to_encode, size_t in_len, bool url) {
 
-    unsigned int len_encoded = (in_len +2) / 3 * 4;
+    size_t len_encoded = (in_len +2) / 3 * 4;
 
     unsigned char trailing_char = url ? '.' : '=';
 
@@ -176,7 +176,7 @@ static std::string decode(String encoded_string, bool remove_linebreaks) {
 
     }
 
-    int length_of_string = encoded_string.length();
+    size_t length_of_string = encoded_string.length();
     if (!length_of_string) return std::string("");
 
     size_t in_len = length_of_string;

--- a/base64.cpp
+++ b/base64.cpp
@@ -49,7 +49,7 @@ const char* base64_chars[2] = {
              "0123456789"
              "-_"};
 
-static std::size_t pos_of_char(const unsigned char chr) {
+static unsigned int pos_of_char(const unsigned char chr) {
  //
  // Return the position of chr within base64_encode()
  //

--- a/base64.cpp
+++ b/base64.cpp
@@ -196,15 +196,15 @@ static std::string decode(String encoded_string, bool remove_linebreaks) {
 
        unsigned int pos_of_char_1 = pos_of_char(encoded_string[pos+1] );
 
-       ret.push_back( ( (pos_of_char(encoded_string[pos+0]) ) << 2 ) + ( (pos_of_char_1 & 0x30 ) >> 4));
+       ret.push_back(static_cast<std::string::value_type>( ( (pos_of_char(encoded_string[pos+0]) ) << 2 ) + ( (pos_of_char_1 & 0x30 ) >> 4)));
 
        if (encoded_string[pos+2] != '=' && encoded_string[pos+2] != '.') { // accept URL-safe base 64 strings, too, so check for '.' also.
 
           unsigned int pos_of_char_2 = pos_of_char(encoded_string[pos+2] );
-          ret.push_back( (( pos_of_char_1 & 0x0f) << 4) + (( pos_of_char_2 & 0x3c) >> 2));
+          ret.push_back(static_cast<std::string::value_type>( (( pos_of_char_1 & 0x0f) << 4) + (( pos_of_char_2 & 0x3c) >> 2)));
 
           if (encoded_string[pos+3] != '=' && encoded_string[pos+3] != '.') {
-             ret.push_back( ( (pos_of_char_2 & 0x03 ) << 6 ) + pos_of_char(encoded_string[pos+3])   );
+             ret.push_back(static_cast<std::string::value_type>( ( (pos_of_char_2 & 0x03 ) << 6 ) + pos_of_char(encoded_string[pos+3])   ));
           }
        }
 

--- a/base64.h
+++ b/base64.h
@@ -17,7 +17,7 @@ std::string base64_encode_pem (std::string const& s);
 std::string base64_encode_mime(std::string const& s);
 
 std::string base64_decode(std::string const& s, bool remove_linebreaks = false);
-std::string base64_encode(unsigned char const*, unsigned int len, bool url = false);
+std::string base64_encode(unsigned char const*, size_t len, bool url = false);
 
 #if __cplusplus >= 201703L
 //


### PR DESCRIPTION
I've fixed a few warnings about going to/from size_t and char. There are other ways of handling these - our goal with the fork was to quiet warnings during build. 