### PR TITLE
Conforming to decode.

### DIFF
--- a/base64.cpp
+++ b/base64.cpp
@@ -74,9 +74,7 @@ static std::string insert_linebreaks(std::string str, size_t distance) {
  //
  // Provided by https://github.com/JomaCorpFX, adapted by me.
  //
-    if (!str.length()) {
-        return "";
-    }
+    if (str.empty()) return std::string();
 
     size_t pos = distance;
 

--- a/base64.cpp
+++ b/base64.cpp
@@ -74,8 +74,6 @@ static std::string insert_linebreaks(std::string str, size_t distance) {
  //
  // Provided by https://github.com/JomaCorpFX, adapted by me.
  //
-    if (str.empty()) return std::string();
-
     size_t pos = distance;
 
     while (pos < str.size()) {


### PR DESCRIPTION
First using empty() and return string() if so, as in the decode function,  but then realised the check is not needed.